### PR TITLE
remove extraneous @wraps

### DIFF
--- a/libextract/__init__.py
+++ b/libextract/__init__.py
@@ -1,1 +1,10 @@
+"""
+    libextract
+    ~~~~~~~~~~
 
+    Beautfully simple data extraction using simple,
+    composable pipelined functions.
+
+    :copyright: (c) 2015 Libextract
+    :license: MIT, see LICENSE for details.
+"""

--- a/libextract/api.py
+++ b/libextract/api.py
@@ -15,10 +15,10 @@ from .xpaths import PARENT_NODES, TEXT_NODES
 from .metrics import text_length
 from statscounter import StatsCounter
 
-DEF_ENC = 'utf-8'
+DEFAULT_ENC = 'utf-8'
 
 
-def articles(document, encoding=DEF_ENC, count=5):
+def articles(document, encoding=DEFAULT_ENC, count=5):
     """
     Given an html *document*, and optionally the *encoding*,
     and the number of predictions (*count*) to return
@@ -34,15 +34,11 @@ def articles(document, encoding=DEF_ENC, count=5):
     def predictor(node):
         return node.getparent(), text_length(node)
 
-    if encoding != DEF_ENC:
-        enc_parse = partial(parse_html, encoding=encoding)
-    else:
-        enc_parse = parse_html
-
+    enc_parse = partial(parse_html, encoding=encoding)
     return pipeline(document, (parse_html, predictor,))
 
 
-def tabular(document, encoding=DEF_ENC, count=5):
+def tabular(document, encoding=DEFAULT_ENC, count=5):
     """
     Given an html *document*, and optionally the *encoding*,
     and the number of predictions (*count*) to return
@@ -56,9 +52,5 @@ def tabular(document, encoding=DEF_ENC, count=5):
     def predictor(node):
         return node, StatsCounter([child.tag for child in node])
 
-    if encoding != DEF_ENC:
-        enc_parse = partial(parse_html, encoding=encoding)
-    else:
-        enc_parse = parse_html
-
+    enc_parse = partial(parse_html, encoding=encoding)
     return pipeline(document, (enc_parse, predictor,))

--- a/libextract/api.py
+++ b/libextract/api.py
@@ -12,7 +12,8 @@ from functools import partial
 from .core import parse_html, pipeline
 from .generators import selects, maximize
 from .xpaths import PARENT_NODES, TEXT_NODES
-from .metrics import StatsCounter
+from .metrics import text_length
+from statscounter import StatsCounter
 
 DEF_ENC = 'utf-8'
 
@@ -31,7 +32,7 @@ def articles(document, encoding=DEF_ENC, count=5):
     @maximize(count, lambda x: x[1])
     @selects(TEXT_NODES) # uses text-extracting xpath
     def predictor(node):
-        return node.getparent(), len(" ".join(node.text_content().split()))
+        return node.getparent(), text_length(node)
 
     if encoding != DEF_ENC:
         enc_parse = partial(parse_html, encoding=encoding)

--- a/libextract/core.py
+++ b/libextract/core.py
@@ -1,13 +1,11 @@
 """
-    libextract
-    ~~~~~~~~~~
+    libextract.core
+    ~~~~~~~~~~~~~~~
 
-    Beautfully simple data extraction using simple,
-    composable pipelined functions.
-
-    :copyright: (c) 2015 Libextract
-    :license: MIT, see LICENSE for details.
+    Implements the core utilities and functions in which
+    libextract is built around.
 """
+
 
 try:
     from cStringIO import StringIO as BytesIO

--- a/libextract/generators.py
+++ b/libextract/generators.py
@@ -55,7 +55,6 @@ def iters(*tags):
     Generates *nodes* using etree.iter
     """
     tags = set(tags)
-    @wraps(iters)
     def decorator(fn):
         @wraps(fn)
         def iterator(node, *args):
@@ -77,7 +76,6 @@ def selects(xpath):
     To get anchor tags (<a>):
     '//a'
     """
-    @wraps(selects)
     def decorator(fn):
         @wraps(fn)
         def selector(node, *args):
@@ -105,7 +103,6 @@ def maximize(top=5, max_fn=select_score):
     Selects the *top* nodes using suing maximizing
     function (*max_fn*).
     """
-    @wraps(maximize)
     def decorator(fn):
         @wraps(fn)
         def iterator(*args):
@@ -124,7 +121,6 @@ def maximize(top=5, max_fn=select_score):
 
 def processes(*tags):
     tags = set(tags)
-    @wraps(processes)
     def decorator(fn):
         @wraps(fn)
         def processor(nodes,*args):

--- a/libextract/metrics.py
+++ b/libextract/metrics.py
@@ -10,6 +10,7 @@
 
 from statscounter import StatsCounter
 
+
 def text_length(node):
     """
     Returns the length of the text contained within


### PR DESCRIPTION
Is there a reason for the excessive ``@wraps``? My understanding is that you want the decorators to be self-documenting, i.e.

```python
u = processes('html')
u.__doc__ == processes.__doc__
```

But it really isn't an issue as most users would most likely just call the decorator afterwards anyways, and there is really no need for any documentation in the "wrapper". This is not from a performance standpoint because the decorator is likely to be only called once during runtime but rather from a more pragmatic viewpoint.